### PR TITLE
[codex] Refresh Rich TUI experience

### DIFF
--- a/docs/plans/2026-03-27-rich-tui-premium-restyle.md
+++ b/docs/plans/2026-03-27-rich-tui-premium-restyle.md
@@ -1,0 +1,171 @@
+# Rich TUI Premium Restyle Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Refresh the entire `lb_ui` terminal surface with a premium graphite-and-teal visual hierarchy while keeping behavior stable.
+
+**Architecture:** Keep the existing `lb_ui` TUI structure intact and concentrate changes inside the shared theme layer plus the Rich dashboard, presenter, table, picker, and form surfaces. The journal remains the primary panel, while every other terminal surface adopts the same restrained chrome so the UI feels cohesive rather than a mix of old and new styling.
+
+**Tech Stack:** Python 3.13, Rich, pytest
+
+---
+
+### Task 1: Baseline and Red Tests
+
+**Files:**
+- Modify: `tests/unit/lb_ui/test_tui_theme.py`
+- Modify: `tests/unit/lb_ui/test_dashboard_rendering.py`
+- Test: `tests/unit/lb_ui/test_dashboard_helpers.py`
+
+**Step 1: Run the current focused baseline**
+
+Run:
+
+```bash
+uv run pytest tests/unit/lb_ui/test_tui_theme.py tests/unit/lb_ui/test_dashboard_helpers.py tests/unit/lb_ui/test_dashboard_rendering.py -m unit_ui
+```
+
+Expected: PASS on the current worktree baseline.
+
+**Step 2: Add failing tests for the premium hierarchy**
+
+Add assertions that capture the intended aesthetic rules:
+
+- the theme exposes distinct title styles for primary and secondary surfaces
+- presenter rules/panels use the secondary border style
+- dashboard log/status empty states use muted copy instead of blank raw output
+
+**Step 3: Run the focused tests and confirm RED**
+
+Run:
+
+```bash
+uv run pytest tests/unit/lb_ui/test_tui_theme.py tests/unit/lb_ui/test_dashboard_rendering.py -m unit_ui
+```
+
+Expected: FAIL only on the newly added assertions.
+
+### Task 2: Shared Theme and Presenter Restyle
+
+**Files:**
+- Modify: `lb_ui/tui/core/theme.py`
+- Modify: `lb_ui/tui/system/components/presenter.py`
+
+**Step 1: Implement the minimal theme additions**
+
+Add only the helpers/constants required by the failing tests:
+
+- stronger distinction between primary/secondary titles
+- muted body/placeholder styling helpers
+- rule styling aligned with the graphite-and-teal palette
+
+**Step 2: Apply the shared presenter styling**
+
+Keep presenter behavior unchanged, but ensure panels and rules inherit the refined secondary treatment.
+
+**Step 3: Run the focused tests**
+
+Run:
+
+```bash
+uv run pytest tests/unit/lb_ui/test_tui_theme.py -m unit_ui
+```
+
+Expected: PASS.
+
+### Task 3: Dashboard Restyle
+
+**Files:**
+- Modify: `lb_ui/tui/system/components/dashboard.py`
+- Modify: `lb_ui/tui/system/components/dashboard_helpers.py`
+- Modify: `tests/unit/lb_ui/test_dashboard_rendering.py`
+
+**Step 1: Implement the premium dashboard treatment**
+
+Refine only presentation:
+
+- cleaner journal/log/status titles
+- muted empty states instead of blank filler lines
+- tighter log rendering with subdued timing metadata
+- more intentional table spacing/placeholder styling
+
+**Step 2: Run the dashboard tests**
+
+Run:
+
+```bash
+uv run pytest tests/unit/lb_ui/test_dashboard_helpers.py tests/unit/lb_ui/test_dashboard_rendering.py -m unit_ui
+```
+
+Expected: PASS.
+
+### Task 4: Presenter, Table, Picker, and Form Restyle
+
+**Files:**
+- Modify: `lb_ui/tui/system/components/presenter.py`
+- Modify: `lb_ui/tui/system/components/table.py`
+- Modify: `lb_ui/tui/system/components/table_layout.py`
+- Modify: `lb_ui/tui/system/components/form.py`
+- Modify: `lb_ui/tui/system/components/flat_picker_panel.py`
+- Modify: `lb_ui/tui/screens/picker_screen.py`
+- Modify: `tests/unit/lb_ui/test_picker_screen.py`
+- Create: `tests/unit/lb_ui/test_tui_components.py`
+
+**Step 1: Add failing tests for the remaining TUI surfaces**
+
+Cover:
+
+- presenter panels/rules reuse the secondary chrome
+- table presenter uses quieter table chrome
+- forms pass styled prompts to Rich
+- picker breadcrumbs and row copy match the premium palette/copy choices
+
+**Step 2: Run the focused tests and confirm RED**
+
+Run:
+
+```bash
+uv run pytest tests/unit/lb_ui/test_picker_screen.py tests/unit/lb_ui/test_tui_components.py -m unit_ui
+```
+
+Expected: FAIL only on the newly added assertions.
+
+**Step 3: Implement the restyle across the remaining TUI surfaces**
+
+Keep behavior unchanged; change only styling, copy, and structural presentation.
+
+**Step 4: Run the focused tests**
+
+Run:
+
+```bash
+uv run pytest tests/unit/lb_ui/test_picker_screen.py tests/unit/lb_ui/test_tui_components.py -m unit_ui
+```
+
+Expected: PASS.
+
+### Task 5: Final Verification
+
+**Files:**
+- Verify only
+
+**Step 1: Run the full focused verification set**
+
+Run:
+
+```bash
+uv run pytest tests/unit/lb_ui/test_tui_theme.py tests/unit/lb_ui/test_dashboard_helpers.py tests/unit/lb_ui/test_dashboard_rendering.py tests/unit/lb_ui/test_picker_screen.py tests/unit/lb_ui/test_tui_components.py tests/unit/lb_ui/test_cli.py -m unit_ui
+```
+
+Expected: PASS.
+
+**Step 2: Review diff for scope**
+
+Run:
+
+```bash
+git diff --stat
+git diff -- lb_ui/tui/core/theme.py lb_ui/tui/system/components/presenter.py lb_ui/tui/system/components/table.py lb_ui/tui/system/components/table_layout.py lb_ui/tui/system/components/form.py lb_ui/tui/system/components/flat_picker_panel.py lb_ui/tui/screens/picker_screen.py lb_ui/tui/system/components/dashboard.py lb_ui/tui/system/components/dashboard_helpers.py tests/unit/lb_ui/test_tui_theme.py tests/unit/lb_ui/test_dashboard_rendering.py tests/unit/lb_ui/test_picker_screen.py tests/unit/lb_ui/test_tui_components.py
+```
+
+Expected: only aesthetic Rich TUI changes plus matching tests/plan.

--- a/lb_app/services/execution_loop.py
+++ b/lb_app/services/execution_loop.py
@@ -172,7 +172,7 @@ class RunExecutionLoop:
         ui_adapter: UIAdapter | None,
     ) -> None:
         """Emit and schedule clearance for the first Ctrl+C warning."""
-        msg = "Press Ctrl+C again to stop the execution"
+        msg = "Graceful stop requested. Press Ctrl+C again within 10s to force stop."
         emit_warning(
             msg,
             dashboard=session.dashboard,

--- a/lb_app/services/run_logging.py
+++ b/lb_app/services/run_logging.py
@@ -35,15 +35,17 @@ def _emit_ui_message(
     dashboard_warning: bool = False,
     ttl: float = 10.0,
 ) -> None:
-    if _emit_via_ui(ui_adapter, level, message):
-        return
-    if _emit_via_dashboard(
+    ui_emitted = _emit_via_ui(ui_adapter, level, message)
+    dashboard_emitted = False
+    if dashboard_warning or not ui_emitted:
+        dashboard_emitted = _emit_via_dashboard(
         dashboard,
         message,
         dashboard_message=dashboard_message,
         dashboard_warning=dashboard_warning,
         ttl=ttl,
-    ):
+    )
+    if ui_emitted or dashboard_emitted:
         return
     print(message)
 

--- a/lb_ui/presenters/dashboard.py
+++ b/lb_ui/presenters/dashboard.py
@@ -18,10 +18,16 @@ def event_status_line(
 ) -> str:
     from lb_ui.tui.core import theme
 
-    status, detail = _event_status_line(event_source, last_event_ts, now=now)
+    status, detail = event_status_parts(event_source, last_event_ts, now=now)
     if status == "waiting":
         return theme.event_status_waiting()
     return theme.event_status_live(event_source, detail)
+
+
+def event_status_parts(
+    event_source: str, last_event_ts: float | None, *, now: float | None = None
+) -> tuple[str, str]:
+    return _event_status_line(event_source, last_event_ts, now=now)
 
 
 __all__ = [
@@ -31,5 +37,6 @@ __all__ = [
     "DashboardStatusSummary",
     "DashboardViewModel",
     "build_dashboard_viewmodel",
+    "event_status_parts",
     "event_status_line",
 ]

--- a/lb_ui/tui/core/theme.py
+++ b/lb_ui/tui/core/theme.py
@@ -7,6 +7,9 @@ RICH_ACCENT = "cyan"
 RICH_ACCENT_BOLD = f"bold {RICH_ACCENT}"
 RICH_BORDER_STYLE = "bright_black"        # subtle grey — secondary panels
 RICH_BORDER_STYLE_ACTIVE = RICH_ACCENT    # cyan — primary/active panels
+RICH_TITLE_SECONDARY = "bold white"
+RICH_META_MUTED = "bright_black"
+RICH_EMPTY_TEXT = "italic bright_black"
 
 # ── Status colours (kept for backward compat with status_text()) ─────────────
 RICH_STATUS_COLORS: dict[str, str] = {
@@ -38,8 +41,16 @@ PRESENTER_TEMPLATES: dict[str, str] = {
 
 # ── Dashboard styles ──────────────────────────────────────────────────────────
 DASHBOARD_HOST_STYLE = "bold white"
-DASHBOARD_ACTION_STYLE = "white"        # was "dim italic" — now legible
+DASHBOARD_ACTION_STYLE = "white"
+DASHBOARD_HEADER_STYLE = "bold white"
+TABLE_ROW_STYLES = ["none", "dim"]
 LOG_TIMING_STYLE = "bright_black"
+ACTION_PHASE_STYLES: dict[str, str] = {
+    "SET": "black on #7fe3d4",
+    "RUN": "black on #5cc8ff",
+    "COL": "black on #b8f28f",
+    "END": "black on #f2c078",
+}
 
 # ── Picker keybinding hint strings ────────────────────────────────────────────
 PICKER_KEYBINDINGS_FLAT_SINGLE = (
@@ -58,8 +69,37 @@ PICKER_KEYBINDINGS_VARIANTS = (
 
 # ── Public helpers ────────────────────────────────────────────────────────────
 
-def panel_title(text: str) -> str:
-    return f"[{RICH_ACCENT_BOLD}]{text}[/{RICH_ACCENT_BOLD}]"
+def panel_title(
+    text: str, meta: str | None = None, *, active: bool = True
+) -> str:
+    title_style = RICH_ACCENT_BOLD if active else RICH_TITLE_SECONDARY
+    if not meta:
+        return f"[{title_style}]{text}[/{title_style}]"
+    meta_style = RICH_ACCENT if active else RICH_META_MUTED
+    return (
+        f"[{title_style}]{text}[/{title_style}] "
+        f"[{RICH_META_MUTED}]•[/{RICH_META_MUTED}] "
+        f"[{meta_style}]{meta}[/{meta_style}]"
+    )
+
+
+def muted(text: str) -> str:
+    return f"[{RICH_META_MUTED}]{text}[/{RICH_META_MUTED}]"
+
+
+def empty_state(text: str) -> str:
+    return f"[{RICH_EMPTY_TEXT}]{text}[/{RICH_EMPTY_TEXT}]"
+
+
+def form_prompt(text: str) -> str:
+    return f"[{RICH_TITLE_SECONDARY}]{text}[/{RICH_TITLE_SECONDARY}]"
+
+
+def action_phase_badge(label: str) -> str:
+    style = ACTION_PHASE_STYLES.get(label)
+    if not style:
+        return label
+    return f"[{style}] {label} [/{style}]"
 
 
 def status_text(status: str) -> str:
@@ -104,7 +144,7 @@ def event_status_live(event_source: str, freshness: str) -> str:
 
 
 def controller_state_line(state: str) -> str:
-    return f"[cyan]Controller:[/cyan] {state}"
+    return f"[{RICH_TITLE_SECONDARY}]Controller[/{RICH_TITLE_SECONDARY}] {muted('•')} {state}"
 
 
 def warning_banner(message: str) -> str:
@@ -113,16 +153,16 @@ def warning_banner(message: str) -> str:
 
 def prompt_toolkit_picker_style() -> Mapping[str, str]:
     return {
-        "selected":         "bg:#006080 fg:white bold",
-        "checked":          "fg:#00cc88 bold",
-        "separator":        "fg:#444444",
-        "frame.border":     "fg:#444444",
-        "frame.label":      "fg:#00aacc bold",
-        "search":           "bg:#1a1a2e fg:#00ccff",
-        "variant-selected": "bg:#004433 fg:#00ff88 bold",
-        "disabled":         "fg:#664444",
-        "path":             "fg:#00aacc bold underline",
-        "title":            "bold",
-        "footer":           "bg:#111111 fg:#666666",
-        "footer.key":       "fg:#00aacc bold",
+        "selected":         "bg:#14323a fg:#eafffb bold",
+        "checked":          "fg:#67d6c3 bold",
+        "separator":        "fg:#3c464d",
+        "frame.border":     "fg:#3c464d",
+        "frame.label":      "fg:#7fe3d4 bold",
+        "search":           "bg:#171c20 fg:#dffcf7",
+        "variant-selected": "bg:#163b38 fg:#effffb bold",
+        "disabled":         "fg:#66727a",
+        "path":             "fg:#7fe3d4 bold",
+        "title":            "fg:#f4fffd bold",
+        "footer":           "bg:#101316 fg:#73818a",
+        "footer.key":       "fg:#7fe3d4 bold",
     }

--- a/lb_ui/tui/screens/picker_screen.py
+++ b/lb_ui/tui/screens/picker_screen.py
@@ -244,7 +244,7 @@ class PickerScreen:
     def _render_path(self) -> str:
         if not self._hierarchy:
             return ""
-        return f"Path: {self._hierarchy.breadcrumb()}"
+        return f"Browse • {self._hierarchy.breadcrumb()}"
 
     def _render_row(self, item: PickItem, is_selected: bool) -> tuple[str, str]:
         if self._hierarchy:
@@ -258,7 +258,7 @@ class PickerScreen:
             style = "class:disabled"
 
         if not self._multi_select:
-            suffix = " \u25b8" if item.variants else ""
+            suffix = "  · options \u25b8" if item.variants else ""
             return style, f"   {item.title}{suffix}"
 
         prefix = "[ ]"
@@ -269,9 +269,9 @@ class PickerScreen:
             prefix = "[x]"
             if item.variants:
                 variant_label = self._selection.selected_variant_title(item)
-                suffix = f" [{variant_label}]" if variant_label else " \u25b8"
+                suffix = f"  · {variant_label}" if variant_label else "  · selected"
         elif item.variants:
-            suffix = " \u25b8"
+            suffix = "  · options \u25b8"
         if self._selection and self._selection.is_selected(item) and not is_selected:
             style = "class:checked"
         return style, f" {prefix} {item.title}{suffix}"
@@ -287,7 +287,7 @@ class PickerScreen:
         else:
             raw = theme.PICKER_KEYBINDINGS_FLAT_SINGLE
 
-        frags: list[tuple[str, str]] = [("class:footer", "  ")]
+        frags: list[tuple[str, str]] = [("class:footer", "  Hints "), ("class:footer", "•   ")]
         for segment in raw.split("  "):
             segment = segment.strip()
             if not segment:
@@ -304,9 +304,9 @@ class PickerScreen:
     def _render_variants(self) -> list[tuple[str, str]]:
         item = self._current_item()
         if not item or not item.variants:
-            return [("", "No options available")]
+            return [("class:disabled", "No options available")]
         fragments: list[tuple[str, str]] = []
-        fragments.append(("class:title", f"Select Option for {item.title}:\n\n"))
+        fragments.append(("class:title", f"Options • {item.title}\n\n"))
         for idx, variant in enumerate(item.variants):
             style = ""
             if idx == self._variant_index:

--- a/lb_ui/tui/system/components/dashboard.py
+++ b/lb_ui/tui/system/components/dashboard.py
@@ -2,10 +2,21 @@
 
 from __future__ import annotations
 
+import os
+import select
+import sys
+import threading
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import IO, List
+
+try:
+    import termios
+    import tty
+except ImportError:  # pragma: no cover - non-POSIX fallback
+    termios = None  # type: ignore[assignment]
+    tty = None  # type: ignore[assignment]
 
 from rich.console import Console
 from rich.layout import Layout
@@ -16,7 +27,7 @@ from rich.table import Table
 from lb_ui.presenters.dashboard import (
     DashboardSnapshot,
     DashboardViewModel,
-    event_status_line,
+    event_status_parts,
 )
 from lb_ui.tui.core.protocols import Dashboard, DashboardFactory
 from lb_ui.tui.core import theme
@@ -36,6 +47,7 @@ class RichDashboard(Dashboard):
         self.console = console
         self.viewmodel = viewmodel
         self.log_buffer: List[str] = []
+        self.raw_log_buffer: List[str] = []
         self.max_log_lines = 20
         self._rollup_helper = PollingRollupHelper(self.log_buffer, summary_only=True)
         self.layout = Layout()
@@ -51,6 +63,9 @@ class RichDashboard(Dashboard):
         self.controller_state: str = "starting\u2026"
         self._warning_message: str | None = None
         self._warning_expires_at: float | None = None
+        self._log_mode = "summary"
+        self._key_listener_thread: threading.Thread | None = None
+        self._key_listener_stop = threading.Event()
 
     @contextmanager
     def live(self) -> Iterator[None]:
@@ -65,9 +80,11 @@ class RichDashboard(Dashboard):
             screen=True,
         ) as live:
             self._live = live
+            self._start_key_listener()
             try:
                 yield None
             finally:
+                self._stop_key_listener()
                 self._live = None
 
     def refresh(self) -> None:
@@ -92,72 +109,183 @@ class RichDashboard(Dashboard):
         self.layout["logs"].size = logs_height
         self._visible_log_lines = max(3, logs_height - 2)
         self.layout["journal"].update(self._render_journal(snapshot))
-        self.layout["status"].update(self._render_status())
+        self.layout["status"].update(self._render_status(snapshot))
         self.layout["logs"].update(self._render_logs(snapshot))
         return self.layout
 
     def _render_logs(self, snapshot: DashboardSnapshot) -> Panel:
         """Render the rolling log stream."""
         max_visible = getattr(self, "_visible_log_lines", self.max_log_lines)
-        lines = self.log_buffer[-max_visible:]
+        lines = self._visible_logs(max_visible)
         table = Table.grid(expand=True)
         table.add_column(ratio=1)
         table.add_column(justify="right", style=theme.LOG_TIMING_STYLE, width=14)
-        for line in lines:
-            message, timing = dashboard_helpers.split_timing(line)
-            table.add_row(message, timing)
+        if not lines:
+            table.add_row(theme.empty_state("No live activity yet"), "")
+        else:
+            for line in lines:
+                message, timing = dashboard_helpers.split_timing(line)
+                table.add_row(message, timing)
         return Panel(
             table,
-            title=theme.panel_title(snapshot.log_metadata.title),
+            title=theme.panel_title(
+                "Activity Log",
+                meta=f"mode: {self._log_mode} • L toggle",
+                active=False,
+            ),
             border_style=theme.RICH_BORDER_STYLE,
         )
 
-    def _render_status(self) -> Panel:
+    def _visible_logs(self, max_visible: int) -> list[str]:
+        source = self.log_buffer if self._log_mode == "summary" else self.raw_log_buffer
+        return source[-max_visible:]
+
+    def _toggle_log_mode(self) -> None:
+        self._log_mode = "all" if self._log_mode == "summary" else "summary"
+        self.refresh()
+
+    def _start_key_listener(self) -> None:
+        if not self._supports_key_toggle():
+            return
+        if self._key_listener_thread and self._key_listener_thread.is_alive():
+            return
+        self._key_listener_stop.clear()
+        self._key_listener_thread = threading.Thread(
+            target=self._key_listener_loop,
+            name="lb-dashboard-keys",
+            daemon=True,
+        )
+        self._key_listener_thread.start()
+
+    def _stop_key_listener(self) -> None:
+        self._key_listener_stop.set()
+        if self._key_listener_thread:
+            self._key_listener_thread.join(timeout=1)
+            self._key_listener_thread = None
+
+    def _supports_key_toggle(self) -> bool:
+        if os.name == "nt":
+            return False
+        if termios is None or tty is None:
+            return False
+        try:
+            return sys.stdin.isatty()
+        except Exception:
+            return False
+
+    def _key_listener_loop(self) -> None:
+        fd = sys.stdin.fileno()
+        old_attrs = termios.tcgetattr(fd)
+        try:
+            tty.setcbreak(fd)
+            while not self._key_listener_stop.is_set():
+                ready, _, _ = select.select([fd], [], [], 0.1)
+                if not ready:
+                    continue
+                chars = os.read(fd, 1)
+                if chars in (b"l", b"L"):
+                    self._toggle_log_mode()
+        except Exception:
+            return
+        finally:
+            try:
+                termios.tcsetattr(fd, termios.TCSADRAIN, old_attrs)
+            except Exception:
+                pass
+
+    def _empty_status_message(self) -> str:
+        return "No active warnings"
+
+    def _status_lines(
+        self,
+        snapshot: DashboardSnapshot,
+        *,
+        now: float | None = None,
+        available_width: int | None = None,
+    ) -> list[str]:
+        status, detail = event_status_parts(
+            self.event_source, self.last_event_ts, now=now
+        )
+        stream = "stream waiting" if status == "waiting" else f"stream live • {detail}"
+        summary = [
+            f"run {snapshot.run_id}",
+            f"controller {self.controller_state}",
+            stream,
+        ]
+        available_width = available_width or getattr(self.console.size, "width", 120) or 120
+        if available_width >= 96:
+            lines = [" • ".join(summary)]
+        else:
+            lines = [summary[0], summary[1], summary[2]]
+
+        if self._warning_message and self._warning_expires_at and now is not None:
+            if now < self._warning_expires_at:
+                lines.append(self._warning_message)
+            else:
+                self._warning_expires_at = None
+                self._warning_message = None
+
+        if len(lines) == (1 if available_width >= 96 else 3):
+            lines.append(self._empty_status_message())
+        return lines
+
+    def _render_status(self, snapshot: DashboardSnapshot) -> Panel:
         """Render controller/event status and transient warnings."""
         now = time.monotonic()
-        warning = None
-        if self._warning_expires_at and now < self._warning_expires_at:
-            warning = self._warning_message
-        elif self._warning_expires_at and now >= self._warning_expires_at:
-            self._warning_expires_at = None
-            self._warning_message = None
-        lines = []
-        lines.append(event_status_line(self.event_source, self.last_event_ts, now=now))
-        lines.append(theme.controller_state_line(self.controller_state))
-        if warning:
-            lines.append(theme.warning_banner(warning))
-        else:
-            lines.append("")
+        lines = self._status_lines(
+            snapshot,
+            now=now,
+            available_width=getattr(self.console.size, "width", 120) or 120,
+        )
+        rendered_lines: list[str] = []
+        for idx, line in enumerate(lines):
+            if line == self._empty_status_message():
+                rendered_lines.append(theme.empty_state(line))
+            elif idx == len(lines) - 1 and line == self._warning_message:
+                rendered_lines.append(theme.warning_banner(line))
+            elif line.startswith("controller "):
+                rendered_lines.append(
+                    theme.controller_state_line(line.removeprefix("controller "))
+                )
+            else:
+                rendered_lines.append(line)
         return Panel(
-            "\n".join(lines),
-            title=theme.panel_title("Status"),
+            "\n".join(rendered_lines),
+            title=theme.panel_title("Run Status", meta="control plane", active=False),
             border_style=theme.RICH_BORDER_STYLE,
         )
 
     def _render_journal(self, snapshot: DashboardSnapshot) -> Panel:
-        table = Table(expand=True, box=None, padding=(0, 1))
-        table.add_column("Host", style=theme.DASHBOARD_HOST_STYLE, width=24)
-        table.add_column("Workload", width=10)
-        table.add_column("Intensity", width=10)
-        table.add_column("Status", justify="center", width=10)
-        table.add_column("Progress", justify="center", width=18)
-        table.add_column("Current Action", style=theme.DASHBOARD_ACTION_STYLE)
-        table.add_column("Last Rep Time", justify="right", width=12)
+        table = Table(
+            expand=True,
+            box=None,
+            padding=(0, 1),
+            header_style=theme.DASHBOARD_HEADER_STYLE,
+        )
+        table.add_column("Host", style=theme.DASHBOARD_HOST_STYLE, width=18, no_wrap=True)
+        table.add_column("Workload", width=20, no_wrap=True, overflow="ellipsis")
+        table.add_column("State", justify="center", width=9, no_wrap=True)
+        table.add_column("Prog", justify="left", width=12, no_wrap=True)
+        table.add_column(
+            "Action",
+            style=theme.DASHBOARD_ACTION_STYLE,
+            ratio=1,
+            overflow="ellipsis",
+            min_width=12,
+        )
 
         for row in snapshot.rows:
             table.add_row(
                 row.host,
-                row.workload,
-                str(row.intensity),
+                f"{row.workload} {theme.muted('•')} {row.intensity}",
                 dashboard_helpers.style_status(row.status),
                 dashboard_helpers.render_progress(row.progress),
-                row.current_action or "[bright_black]\u2014[/bright_black]",
-                row.last_rep_time,
+                dashboard_helpers.render_action(row.current_action, row.last_rep_time),
             )
 
         return Panel(
             table,
-            title=theme.panel_title(f"Run Journal \u00b7 {snapshot.run_id}"),
+            title=theme.panel_title("Run Journal", meta=snapshot.run_id),
             border_style=theme.RICH_BORDER_STYLE_ACTIVE,
         )
 
@@ -166,6 +294,7 @@ class RichDashboard(Dashboard):
         if not message or not message.strip():
             return
         stripped = message.strip()
+        self.raw_log_buffer.append(stripped)
         if self._rollup_helper.maybe_rollup(stripped):
             self._write_ui_log(stripped)
             self._trim_log_buffer()
@@ -187,6 +316,8 @@ class RichDashboard(Dashboard):
         trim_target = getattr(self, "_visible_log_lines", self.max_log_lines) * 5
         if len(self.log_buffer) > trim_target:
             del self.log_buffer[:-trim_target]
+        if len(self.raw_log_buffer) > trim_target:
+            del self.raw_log_buffer[:-trim_target]
 
     def mark_event(self, source: str) -> None:
         """Record that an event arrived from the given source (e.g., tcp/stdout)."""

--- a/lb_ui/tui/system/components/dashboard_helpers.py
+++ b/lb_ui/tui/system/components/dashboard_helpers.py
@@ -23,6 +23,35 @@ def render_progress(progress_str: str) -> str:
         return progress_str
 
 
+def _action_phase_label(action: str) -> str | None:
+    normalized = action.strip().lower().replace("_", " ")
+    if not normalized:
+        return None
+    if any(token in normalized for token in ("setup", "install", "bootstrap", "prepare", "provision", "init")):
+        return "SET"
+    if any(token in normalized for token in ("collect", "metric", "parse", "export")):
+        return "COL"
+    if any(token in normalized for token in ("teardown", "cleanup", "final", "stop", "close")):
+        return "END"
+    if any(token in normalized for token in ("run", "exec", "benchmark", "stress", "fio", "workload")):
+        return "RUN"
+    return None
+
+
+def render_action(action: str, last_rep_time: str) -> str:
+    if not action:
+        return theme.empty_state("idle")
+
+    parts: list[str] = []
+    phase = _action_phase_label(action)
+    if phase:
+        parts.append(theme.action_phase_badge(phase))
+    parts.append(action)
+    if last_rep_time:
+        parts.append(theme.muted(f"• {last_rep_time}"))
+    return " ".join(parts)
+
+
 def computed_journal_height(row_count: int, term_height: int) -> int:
     """Pick a journal height that leaves room for logs."""
     min_height = min(30, max(10, row_count + 5))

--- a/lb_ui/tui/system/components/dashboard_rollup.py
+++ b/lb_ui/tui/system/components/dashboard_rollup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Dict, Tuple
 
 from rich.markup import escape
@@ -31,6 +32,8 @@ class PollingRollupHelper:
         if not parsed:
             return False
         phase, host, task_message = parsed
+        if self._maybe_rollup_run_status(phase, host, task_message):
+            return True
         base = task_message
         if base.startswith("workload_runner : "):
             base = base.split(" : ", 1)[1].strip()
@@ -90,6 +93,25 @@ class PollingRollupHelper:
         self._log_buffer.append(display_line)
         return True
 
+    def _maybe_rollup_run_status(self, phase: str, host: str, message: str) -> bool:
+        if not phase.startswith("run "):
+            return False
+        if not self._is_run_status_message(message):
+            return False
+        host_prefix = f"({host}) " if host else ""
+        display_line = escape(f"• [{phase}] {host_prefix}{message}")
+        search_prefix = f"• [{phase}] {host_prefix}"
+        for idx in range(len(self._log_buffer) - 1, -1, -1):
+            existing = self._normalize_log_line(self._log_buffer[idx])
+            if not existing.startswith(search_prefix):
+                continue
+            existing_message = existing[len(search_prefix) :].strip()
+            if self._is_run_status_message(existing_message):
+                self._log_buffer[idx] = display_line
+                return True
+        self._log_buffer.append(display_line)
+        return True
+
     def _update_polling_summary(self, phase: str, host: str) -> None:
         poll_key = (phase, host, "Poll LB_EVENT stream", "done")
         delay_key = (phase, host, "Delay", "done")
@@ -128,6 +150,10 @@ class PollingRollupHelper:
     @staticmethod
     def _normalize_log_line(line: str) -> str:
         return line.replace("\\[", "[").replace("\\]", "]")
+
+    @staticmethod
+    def _is_run_status_message(message: str) -> bool:
+        return re.match(r"^\d+/\d+\s+\w+", message) is not None
 
     @staticmethod
     def _parse_bullet_line(line: str) -> tuple[str, str, str] | None:

--- a/lb_ui/tui/system/components/flat_picker_panel.py
+++ b/lb_ui/tui/system/components/flat_picker_panel.py
@@ -43,7 +43,7 @@ class FlatPickerPanel:
         row_renderer: RowRenderer,
         preview_renderer: PreviewRenderer | None = None,
         fallback_preview_renderer: PreviewRenderer | None = None,
-        search_prompt: str = "Search: ",
+        search_prompt: str = "Filter › ",
         search_style: str = "class:search",
         config: FlatPickerPanelConfig | None = None,
     ) -> None:

--- a/lb_ui/tui/system/components/form.py
+++ b/lb_ui/tui/system/components/form.py
@@ -1,6 +1,7 @@
 from rich.console import Console
 from rich.prompt import Prompt, Confirm
 from lb_ui.tui.core.protocols import Form
+from lb_ui.tui.core import theme
 
 
 class RichForm(Form):
@@ -10,16 +11,21 @@ class RichForm(Form):
     def ask(
         self, prompt: str, default: str | None = None, password: bool = False
     ) -> str:
+        styled_prompt = theme.form_prompt(prompt)
         if default is not None:
             return str(
                 Prompt.ask(
-                    prompt,
+                    styled_prompt,
                     console=self._console,
                     default=default,
                     password=password,
                 )
             )
-        return str(Prompt.ask(prompt, console=self._console, password=password))
+        return str(Prompt.ask(styled_prompt, console=self._console, password=password))
 
     def confirm(self, prompt: str, default: bool = True) -> bool:
-        return Confirm.ask(prompt, console=self._console, default=default)
+        return Confirm.ask(
+            theme.form_prompt(prompt),
+            console=self._console,
+            default=default,
+        )

--- a/lb_ui/tui/system/components/presenter.py
+++ b/lb_ui/tui/system/components/presenter.py
@@ -19,16 +19,23 @@ class _RichPresenterSink(PresenterSink):
         title: str | None,
         border_style: str | None,
     ) -> None:
+        styled_title = theme.panel_title(title, active=False) if title else None
         self._console.print(
             Panel(
                 message,
-                title=title,
+                title=styled_title,
                 border_style=border_style or theme.RICH_BORDER_STYLE,
             )
         )
 
     def emit_rule(self, title: str) -> None:
-        self._console.print(Rule(title))
+        self._console.print(
+            Rule(
+                theme.panel_title(title, active=False),
+                style=theme.RICH_BORDER_STYLE,
+                characters="─",
+            )
+        )
 
 
 class RichPresenter(Presenter):

--- a/lb_ui/tui/system/components/table.py
+++ b/lb_ui/tui/system/components/table.py
@@ -11,11 +11,16 @@ class RichTablePresenter(TablePresenter):
 
     def show(self, table: TableModel) -> None:
         rich_table = build_rich_table(
-            table,
+            TableModel(
+                title=theme.panel_title(table.title, active=False),
+                columns=table.columns,
+                rows=table.rows,
+            ),
             console=self._console,
-            show_lines=True,
+            show_lines=False,
             border_style=theme.RICH_BORDER_STYLE,
-            header_style=theme.RICH_ACCENT_BOLD,
-            title_style=theme.RICH_ACCENT_BOLD,
+            header_style=theme.DASHBOARD_HEADER_STYLE,
+            title_style=theme.RICH_TITLE_SECONDARY,
+            row_styles=theme.TABLE_ROW_STYLES,
         )
         self._console.print(rich_table)

--- a/lb_ui/tui/system/components/table_layout.py
+++ b/lb_ui/tui/system/components/table_layout.py
@@ -34,6 +34,7 @@ def build_rich_table(
     header_style: str | None = None,
     title_style: str | None = None,
     box_style: box.Box = box.ROUNDED,
+    row_styles: list[str] | None = None,
 ) -> Table:
     """
     Build a Rich Table from a TableModel that fits the current terminal width.
@@ -62,6 +63,7 @@ def build_rich_table(
         border_style=border_style or theme.RICH_BORDER_STYLE,
         header_style=header_style or theme.RICH_ACCENT_BOLD,
         title_style=title_style or theme.RICH_ACCENT_BOLD,
+        row_styles=row_styles or [],
     )
 
     def _cell_width(value: str) -> int:

--- a/tests/unit/lb_app/test_run_logging.py
+++ b/tests/unit/lb_app/test_run_logging.py
@@ -1,0 +1,65 @@
+"""Tests for run logging helpers."""
+
+from __future__ import annotations
+
+from io import StringIO
+
+import pytest
+
+from lb_app.services.run_logging import emit_warning
+
+
+pytestmark = pytest.mark.unit_ui
+
+
+class _RecordingUIAdapter:
+    def __init__(self) -> None:
+        self.warnings: list[str] = []
+
+    def show_warning(self, message: str) -> None:
+        self.warnings.append(message)
+
+    def show_info(self, message: str) -> None:
+        raise AssertionError(f"unexpected info: {message}")
+
+
+class _RecordingDashboard:
+    def __init__(self) -> None:
+        self.warnings: list[tuple[str, float]] = []
+        self.logs: list[str] = []
+        self.refresh_calls = 0
+
+    def add_log(self, line: str) -> None:
+        self.logs.append(line)
+
+    def refresh(self) -> None:
+        self.refresh_calls += 1
+
+    def mark_event(self, source: str) -> None:
+        _ = source
+
+    def set_warning(self, message: str, ttl: float = 10.0) -> None:
+        self.warnings.append((message, ttl))
+
+
+def test_emit_warning_reaches_dashboard_banner_even_with_ui_adapter() -> None:
+    ui_adapter = _RecordingUIAdapter()
+    dashboard = _RecordingDashboard()
+    log_file = StringIO()
+
+    emit_warning(
+        "Press Ctrl+C again within 10s to force stop.",
+        dashboard=dashboard,
+        ui_adapter=ui_adapter,
+        log_file=log_file,
+        ui_stream_log_file=None,
+        ttl=10.0,
+    )
+
+    assert ui_adapter.warnings == ["Press Ctrl+C again within 10s to force stop."]
+    assert dashboard.warnings == [
+        ("Press Ctrl+C again within 10s to force stop.", 10.0)
+    ]
+    assert dashboard.logs == []
+    assert dashboard.refresh_calls == 1
+    assert log_file.getvalue() == "Press Ctrl+C again within 10s to force stop.\n"

--- a/tests/unit/lb_ui/test_dashboard_helpers.py
+++ b/tests/unit/lb_ui/test_dashboard_helpers.py
@@ -40,3 +40,28 @@ def test_render_progress_no_slash() -> None:
 def test_render_progress_malformed() -> None:
     result = dashboard_helpers.render_progress("a/b")
     assert result == "a/b"
+
+
+def test_render_action_with_phase_badge_for_run() -> None:
+    result = dashboard_helpers.render_action("container_run", "1.2s")
+    assert "RUN" in result
+    assert "container_run" in result
+    assert "1.2s" in result
+
+
+def test_render_action_with_phase_badge_for_collection() -> None:
+    result = dashboard_helpers.render_action("collect metrics", "")
+    assert "COL" in result
+    assert "collect metrics" in result
+
+
+def test_render_action_without_known_phase_has_no_badge() -> None:
+    result = dashboard_helpers.render_action("warming cache", "")
+    assert "warming cache" in result
+    assert "RUN" not in result
+    assert "COL" not in result
+
+
+def test_render_action_empty_uses_idle_placeholder() -> None:
+    result = dashboard_helpers.render_action("", "")
+    assert "idle" in result

--- a/tests/unit/lb_ui/test_dashboard_rendering.py
+++ b/tests/unit/lb_ui/test_dashboard_rendering.py
@@ -162,3 +162,20 @@ def test_dashboard_logs_toggle_to_all_mode_shows_raw_lines() -> None:
 
     assert "mode: all" in rendered
     assert "Poll LB_EVENT stream" in rendered
+
+
+def test_dashboard_logs_summary_compresses_run_status_updates() -> None:
+    dash = _make_dashboard()
+    dash.add_log("• [run fio] (host1) 1/3 running")
+    dash.add_log("• [run fio] (host1) 2/3 running")
+    snapshot = dash.viewmodel.snapshot.return_value
+
+    rendered = _render_logs_to_str(dash, snapshot)
+
+    assert "2/3 running" in rendered
+    assert "1/3 running" not in rendered
+
+    dash._toggle_log_mode()
+    rendered_all = _render_logs_to_str(dash, snapshot)
+    assert "1/3 running" in rendered_all
+    assert "2/3 running" in rendered_all

--- a/tests/unit/lb_ui/test_dashboard_rendering.py
+++ b/tests/unit/lb_ui/test_dashboard_rendering.py
@@ -33,6 +33,21 @@ def _render_journal_to_str(dash: RichDashboard, snapshot: Any) -> str:
     return cap_console.file.getvalue()  # type: ignore[union-attr]
 
 
+def _render_status_to_str(dash: RichDashboard) -> str:
+    cap_console = Console(file=StringIO(), force_terminal=True, width=120)
+    snapshot = dash.viewmodel.snapshot.return_value
+    panel = dash._render_status(snapshot)
+    cap_console.print(panel)
+    return cap_console.file.getvalue()  # type: ignore[union-attr]
+
+
+def _render_logs_to_str(dash: RichDashboard, snapshot: Any) -> str:
+    cap_console = Console(file=StringIO(), force_terminal=True, width=120)
+    panel = dash._render_logs(snapshot)
+    cap_console.print(panel)
+    return cap_console.file.getvalue()  # type: ignore[union-attr]
+
+
 def test_dashboard_journal_renders_progress_bar_for_fractional_progress() -> None:
     console = Console(force_terminal=True, width=120)
     viewmodel = MagicMock()
@@ -52,7 +67,7 @@ def test_dashboard_journal_renders_progress_bar_for_fractional_progress() -> Non
     assert "\u2588" in rendered  # █
 
 
-def test_dashboard_journal_uses_placeholder_for_empty_action() -> None:
+def test_dashboard_journal_uses_idle_placeholder_for_empty_action() -> None:
     console = Console(force_terminal=True, width=120)
     viewmodel = MagicMock()
     row = MagicMock()
@@ -68,4 +83,82 @@ def test_dashboard_journal_uses_placeholder_for_empty_action() -> None:
     )
     dash = RichDashboard(console, viewmodel)
     rendered = _render_journal_to_str(dash, snapshot)
-    assert "\u2014" in rendered  # —
+    assert "idle" in rendered
+
+
+def test_dashboard_status_renders_empty_warning_copy() -> None:
+    dash = _make_dashboard()
+    rendered = _render_status_to_str(dash)
+    assert "No active warnings" in rendered
+
+
+def test_dashboard_status_uses_compact_header_on_wide_layout() -> None:
+    dash = _make_dashboard()
+    dash.set_controller_state("running")
+    dash.mark_event("tcp")
+    dash.last_event_ts = 9.0
+    snapshot = dash.viewmodel.snapshot.return_value
+
+    lines = dash._status_lines(snapshot, now=10.2, available_width=120)
+
+    assert "run test-run" in lines[0]
+    assert "controller running" in lines[0]
+    assert "stream live" in lines[0]
+    assert "1.2s ago" in lines[0]
+    assert lines[1] == dash._empty_status_message()
+
+
+def test_dashboard_status_falls_back_to_multiline_on_narrow_layout() -> None:
+    console = Console(force_terminal=True, width=70)
+    viewmodel = MagicMock()
+    viewmodel.snapshot.return_value = MagicMock(
+        run_id="test-run",
+        row_count=1,
+        rows=[],
+        log_metadata=MagicMock(title="Logs"),
+    )
+    dash = RichDashboard(console, viewmodel)
+    dash.set_controller_state("running")
+    dash.mark_event("tcp")
+    dash.last_event_ts = 9.0
+    snapshot = dash.viewmodel.snapshot.return_value
+
+    lines = dash._status_lines(snapshot, now=10.2, available_width=70)
+
+    assert lines[0].startswith("run test-run")
+    assert lines[1].startswith("controller running")
+    assert lines[2].startswith("stream live")
+    assert "1.2s ago" in lines[2]
+
+
+def test_dashboard_logs_render_empty_state_copy() -> None:
+    dash = _make_dashboard()
+    snapshot = dash.viewmodel.snapshot.return_value
+    rendered = _render_logs_to_str(dash, snapshot)
+    assert "No live activity yet" in rendered
+
+
+def test_dashboard_logs_default_to_summary_mode() -> None:
+    dash = _make_dashboard()
+    dash.add_log("• [poll] Poll LB_EVENT stream done in 0.5s")
+    dash.add_log("• [poll] Delay done in 1.0s")
+    snapshot = dash.viewmodel.snapshot.return_value
+
+    rendered = _render_logs_to_str(dash, snapshot)
+
+    assert "mode: summary" in rendered
+    assert "Polling loop" in rendered
+    assert "Poll LB_EVENT stream" not in rendered
+
+
+def test_dashboard_logs_toggle_to_all_mode_shows_raw_lines() -> None:
+    dash = _make_dashboard()
+    dash.add_log("• [poll] Poll LB_EVENT stream done in 0.5s")
+    dash.add_log("• [poll] Delay done in 1.0s")
+    dash._toggle_log_mode()
+    snapshot = dash.viewmodel.snapshot.return_value
+
+    rendered = _render_logs_to_str(dash, snapshot)
+
+    assert "mode: all" in rendered
+    assert "Poll LB_EVENT stream" in rendered

--- a/tests/unit/lb_ui/test_dashboard_rollup.py
+++ b/tests/unit/lb_ui/test_dashboard_rollup.py
@@ -28,3 +28,15 @@ def test_polling_rollup_ignores_failed_tasks() -> None:
 
     assert helper.maybe_rollup("• [run dummy] Poll LB_EVENT stream failed") is False
     assert log_buffer == []
+
+
+def test_polling_rollup_keeps_only_latest_run_status_per_host() -> None:
+    log_buffer: list[str] = []
+    helper = PollingRollupHelper(log_buffer, summary_only=True)
+
+    assert helper.maybe_rollup("• [run fio] (host1) 1/3 running")
+    assert helper.maybe_rollup("• [run fio] (host1) 2/3 running")
+
+    assert len(log_buffer) == 1
+    assert "2/3 running" in log_buffer[0]
+    assert "1/3 running" not in log_buffer[0]

--- a/tests/unit/lb_ui/test_picker_screen.py
+++ b/tests/unit/lb_ui/test_picker_screen.py
@@ -74,6 +74,13 @@ def test_picker_screen_render_footer_hierarchical() -> None:
     assert "back" in full_text
 
 
+def test_picker_screen_render_path_uses_browse_copy() -> None:
+    leaf = SelectionNode(id="leaf", label="Leaf", kind="leaf")
+    root = SelectionNode(id="root", label="Root", kind="root", children=[leaf])
+    screen = PickerScreen(title="Test", root=root)
+    assert "Browse" in screen._render_path()
+
+
 def test_picker_row_shows_arrow_for_item_with_variants_single_select() -> None:
     variants = [PickItem(id="low", title="low"), PickItem(id="high", title="high")]
     items = [
@@ -83,6 +90,7 @@ def test_picker_row_shows_arrow_for_item_with_variants_single_select() -> None:
     screen = PickerScreen(title="Test", items=items, multi_select=False)
     _, text = screen._render_row(items[1], is_selected=False)
     assert "\u25b8" in text  # ▸
+    assert "options" in text
 
 
 def test_picker_row_no_arrow_for_plain_item_single_select() -> None:

--- a/tests/unit/lb_ui/test_tui_components.py
+++ b/tests/unit/lb_ui/test_tui_components.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import pytest
+
+from lb_ui.tui.core import theme
+from lb_ui.tui.system.components.form import RichForm
+from lb_ui.tui.system.components.presenter import RichPresenter
+from lb_ui.tui.system.components.table import RichTablePresenter
+from lb_ui.tui.system.models import TableModel
+
+pytestmark = pytest.mark.unit_ui
+
+
+class _FakeConsole:
+    def __init__(self) -> None:
+        self.renderables: list[object] = []
+
+    def print(self, renderable: object) -> None:
+        self.renderables.append(renderable)
+
+
+def test_rich_presenter_panel_uses_secondary_title_markup() -> None:
+    console = _FakeConsole()
+    presenter = RichPresenter(console)  # type: ignore[arg-type]
+
+    presenter.panel("Hello world", title="Deploy")
+
+    panel = console.renderables[0]
+    assert getattr(panel, "border_style") == theme.RICH_BORDER_STYLE
+    assert theme.RICH_TITLE_SECONDARY in str(getattr(panel, "title"))
+
+
+def test_rich_presenter_rule_uses_subtle_rule_style() -> None:
+    console = _FakeConsole()
+    presenter = RichPresenter(console)  # type: ignore[arg-type]
+
+    presenter.rule("Section")
+
+    rule = console.renderables[0]
+    assert getattr(rule, "style") == theme.RICH_BORDER_STYLE
+    assert getattr(rule, "characters") == "─"
+
+
+def test_rich_table_presenter_uses_quieter_table_chrome() -> None:
+    console = _FakeConsole()
+    presenter = RichTablePresenter(console)  # type: ignore[arg-type]
+
+    presenter.show(
+        TableModel(
+            title="Workloads",
+            columns=["Name", "Status"],
+            rows=[["fio", "done"]],
+        )
+    )
+
+    table = console.renderables[0]
+    assert getattr(table, "show_lines") is False
+    assert getattr(table, "row_styles") == ["none", "dim"]
+    title = getattr(table, "title")
+    assert getattr(table, "title_style") == theme.RICH_TITLE_SECONDARY
+    assert getattr(title, "plain") == "Workloads"
+
+
+def test_rich_form_styles_prompt_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, str] = {}
+
+    def fake_prompt_ask(prompt: str, *, console: object, default: str, password: bool) -> str:
+        captured["ask"] = prompt
+        return "value"
+
+    def fake_confirm_ask(prompt: str, *, console: object, default: bool) -> bool:
+        captured["confirm"] = prompt
+        return True
+
+    monkeypatch.setattr(
+        "lb_ui.tui.system.components.form.Prompt.ask",
+        fake_prompt_ask,
+    )
+    monkeypatch.setattr(
+        "lb_ui.tui.system.components.form.Confirm.ask",
+        fake_confirm_ask,
+    )
+
+    form = RichForm(console=object())  # type: ignore[arg-type]
+    assert form.ask("Target host", default="node-1") == "value"
+    assert form.confirm("Continue?") is True
+    assert theme.RICH_TITLE_SECONDARY in captured["ask"]
+    assert theme.RICH_TITLE_SECONDARY in captured["confirm"]

--- a/tests/unit/lb_ui/test_tui_theme.py
+++ b/tests/unit/lb_ui/test_tui_theme.py
@@ -32,6 +32,13 @@ def test_theme_panel_title_wraps_accent() -> None:
     assert theme.RICH_ACCENT_BOLD in title
 
 
+def test_theme_panel_title_supports_secondary_meta() -> None:
+    title = theme.panel_title("Activity Log", meta="latest events", active=False)
+    assert "Activity Log" in title
+    assert "latest events" in title
+    assert "bright_black" in title
+
+
 def test_theme_accent_is_cyan() -> None:
     assert theme.RICH_ACCENT == "cyan"
 
@@ -72,3 +79,9 @@ def test_theme_picker_style_has_footer_keys() -> None:
     styles = theme.prompt_toolkit_picker_style()
     assert "footer" in styles
     assert "footer.key" in styles
+
+
+def test_theme_picker_style_uses_graphite_teal_palette() -> None:
+    styles = theme.prompt_toolkit_picker_style()
+    assert styles["frame.border"] == "fg:#3c464d"
+    assert styles["footer.key"] == "fg:#7fe3d4 bold"


### PR DESCRIPTION
## Summary
- refresh the Rich TUI with a cohesive graphite-and-teal visual system across dashboard, picker, presenter, tables, and forms
- improve the live dashboard with a compact status header, lightweight action phase badges, and a summary/all log toggle
- add focused UI test coverage for the new theme, dashboard rendering, picker copy, and shared TUI components

## Validation
- `uv run pytest tests/unit/lb_ui -m unit_ui`

## Impact
This makes the terminal experience more consistent and easier to scan during runs without changing the underlying benchmark workflow.