### PR TITLE
[codex] Fix run lifecycle cleanup and persistence scaling

### DIFF
--- a/lb_app/services/interfaces.py
+++ b/lb_app/services/interfaces.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
         _RemoteSession,
     )
     from lb_app.services.run_output import AnsibleOutputFormatter
+    from lb_app.services.run_execution import AttachedHandler
     from lb_app.ui_interfaces import UIAdapter
     from lb_controller.api import BenchmarkController, RunExecutionSummary
     from lb_controller.api import StopToken
@@ -58,8 +59,8 @@ class IRunService(Protocol):
 
     def _attach_controller_jsonl(
         self, context: RunContext, session: _RemoteSession
-    ) -> Handler: ...
+    ) -> AttachedHandler: ...
 
     def _attach_controller_loki(
         self, context: RunContext, session: _RemoteSession
-    ) -> Handler | None: ...
+    ) -> AttachedHandler | None: ...

--- a/lb_app/services/remote_run_coordinator.py
+++ b/lb_app/services/remote_run_coordinator.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from types import TracebackType
 from typing import TYPE_CHECKING
 
@@ -27,6 +26,7 @@ from lb_app.ui_interfaces import UIAdapter
 
 if TYPE_CHECKING:
     from lb_app.services.interfaces import IRunService
+    from lb_app.services.run_execution import AttachedHandler
 
 
 class ControllerLogHandlers:
@@ -38,7 +38,7 @@ class ControllerLogHandlers:
         self._service = service
         self._context = context
         self._session = session
-        self._handlers: list[logging.Handler | None] = []
+        self._handlers: list[AttachedHandler | None] = []
 
     def __enter__(self) -> "ControllerLogHandlers":
         jsonl_handler = self._service._attach_controller_jsonl(
@@ -56,12 +56,12 @@ class ControllerLogHandlers:
         _exc: BaseException | None,
         _tb: TracebackType | None,
     ) -> None:
-        for handler in self._handlers:
-            if not handler:
+        for attached in self._handlers:
+            if not attached:
                 continue
-            logging.getLogger().removeHandler(handler)
+            attached.logger.removeHandler(attached.handler)
             try:
-                handler.close()
+                attached.handler.close()
             except Exception:
                 pass
         self._handlers = []
@@ -90,64 +90,91 @@ class RemoteRunCoordinator:
         session = self._service._prepare_remote_session(
             context, run_id, ui_adapter, stop_token
         )
+        tailer = None
 
-        with ControllerLogHandlers(self._service, context, session):
-            if not session.stop_token.should_stop() and not pending_exists(
-                session.journal,
-                context.target_tests,
-                context.config.remote_hosts or [],
-                context.config.repetitions,
-                allow_skipped=session.resume_requested,
-            ):
-                return self._service._short_circuit_empty_run(
-                    context, session, ui_adapter
+        try:
+            with ControllerLogHandlers(self._service, context, session):
+                if not session.stop_token.should_stop() and not pending_exists(
+                    session.journal,
+                    context.target_tests,
+                    context.config.remote_hosts or [],
+                    context.config.repetitions,
+                    allow_skipped=session.resume_requested,
+                ):
+                    return self._service._short_circuit_empty_run(
+                        context, session, ui_adapter
+                    )
+
+                pipeline = self._service._build_event_pipeline(
+                    context, session, formatter, output_callback, ui_adapter, emit_timing
                 )
 
-            pipeline = self._service._build_event_pipeline(
-                context, session, formatter, output_callback, ui_adapter, emit_timing
-            )
-
-            controller = BenchmarkController(
-                context.config,
-                ControllerOptions(
-                    output_callback=pipeline.output_cb,
-                    output_formatter=formatter,
-                    journal_refresh=(
-                        session.dashboard.refresh if session.dashboard else None
+                controller = BenchmarkController(
+                    context.config,
+                    ControllerOptions(
+                        output_callback=pipeline.output_cb,
+                        output_formatter=formatter,
+                        journal_refresh=(
+                            session.dashboard.refresh if session.dashboard else None
+                        ),
+                        stop_token=session.stop_token,
+                        state_machine=session.controller_state,
                     ),
-                    stop_token=session.stop_token,
-                    state_machine=session.controller_state,
-                ),
-            )
-            pipeline.controller_ref["controller"] = controller
-            if formatter:
-                formatter.host_label = ",".join(
-                    h.name for h in context.config.remote_hosts
+                )
+                pipeline.controller_ref["controller"] = controller
+                if formatter:
+                    formatter.host_label = ",".join(
+                        h.name for h in context.config.remote_hosts
+                    )
+
+                tailer = maybe_start_event_tailer(
+                    controller,
+                    pipeline.event_from_payload,
+                    pipeline.ingest_event,
+                    formatter,
                 )
 
-            tailer = maybe_start_event_tailer(
-                controller,
-                pipeline.event_from_payload,
-                pipeline.ingest_event,
-                formatter,
-            )
+                summary = self._service._run_controller_loop(
+                    controller=controller,
+                    context=context,
+                    session=session,
+                    pipeline=pipeline,
+                    ui_adapter=ui_adapter,
+                )
+                return RunResult(
+                    context=context,
+                    summary=summary,
+                    journal_path=session.journal_path,
+                    log_path=session.log_path,
+                    ui_log_path=session.ui_stream_log_path,
+                )
+        finally:
+            self._cleanup_session(session, tailer)
 
-            summary = self._service._run_controller_loop(
-                controller=controller,
-                context=context,
-                session=session,
-                pipeline=pipeline,
-                ui_adapter=ui_adapter,
-            )
-
-            if tailer:
-                tailer.stop()
+    @staticmethod
+    def _cleanup_session(session: _RemoteSession, tailer: object | None) -> None:
+        if tailer is not None:
+            try:
+                stop = getattr(tailer, "stop", None)
+                if callable(stop):
+                    stop()
+            except Exception:
+                pass
+        try:
             session.sink.close()
+        except Exception:
+            pass
+        try:
+            session.log_file.close()
+        except Exception:
+            pass
+        ui_stream_log_file = session.ui_stream_log_file
+        if ui_stream_log_file is not None:
+            try:
+                ui_stream_log_file.close()
+            except Exception:
+                pass
+        try:
             session.stop_token.restore()
-            return RunResult(
-                context=context,
-                summary=summary,
-                journal_path=session.journal_path,
-                log_path=session.log_path,
-                ui_log_path=session.ui_stream_log_path,
-            )
+        except Exception:
+            pass

--- a/lb_app/services/run_execution.py
+++ b/lb_app/services/run_execution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import logging
 import platform
 from typing import Any, Callable
@@ -39,15 +40,23 @@ from lb_app.ui_interfaces import UIAdapter
 from lb_common.api import JsonlLogFormatter, attach_jsonl_handler, attach_loki_handler
 
 
+@dataclass(frozen=True)
+class AttachedHandler:
+    """Handler paired with the logger that owns it."""
+
+    logger: logging.Logger
+    handler: logging.Handler
+
+
 class ControllerLogAttachmentService:
     """Attach structured logging handlers for the controller."""
 
     @staticmethod
-    def attach_jsonl(context: RunContext, session: _RemoteSession) -> logging.Handler:
+    def attach_jsonl(context: RunContext, session: _RemoteSession) -> AttachedHandler:
         _ = context
         controller_logger = logging.getLogger("lb_controller")
         controller_logger.setLevel(logging.INFO)
-        return attach_jsonl_handler(
+        handler = attach_jsonl_handler(
             controller_logger,
             output_dir=session.journal_path.parent,
             component="controller",
@@ -57,11 +66,12 @@ class ControllerLogAttachmentService:
             package="lb_controller",
             repetition=1,
         )
+        return AttachedHandler(logger=controller_logger, handler=handler)
 
     @staticmethod
     def attach_loki(
         context: RunContext, session: _RemoteSession
-    ) -> logging.Handler | None:
+    ) -> AttachedHandler | None:
         loki_cfg = context.config.loki
         handler = attach_loki_handler(
             logging.getLogger(),
@@ -93,7 +103,8 @@ class ControllerLogAttachmentService:
                     repetition=1,
                 )
             )
-        return handler
+            return AttachedHandler(logger=logging.getLogger(), handler=handler)
+        return None
 
 
 class RunExecutionCoordinator:
@@ -154,19 +165,8 @@ class RunExecutionCoordinator:
             session.log_file.flush()
         except Exception:
             pass
-        session.sink.close()
-        try:
-            session.log_file.close()
-        except Exception:
-            pass
-        if session.ui_stream_log_file:
-            try:
-                session.ui_stream_log_file.close()
-            except Exception:
-                pass
         if ui_adapter:
             ui_adapter.show_info(msg)
-        session.stop_token.restore()
         return RunResult(
             context=context,
             summary=None,
@@ -252,12 +252,12 @@ class RunExecutionCoordinator:
 
     def _attach_controller_jsonl(
         self, context: RunContext, session: _RemoteSession
-    ) -> logging.Handler:
+    ) -> AttachedHandler:
         return self._log_attachment_service.attach_jsonl(context, session)
 
     def _attach_controller_loki(
         self, context: RunContext, session: _RemoteSession
-    ) -> logging.Handler | None:
+    ) -> AttachedHandler | None:
         return self._log_attachment_service.attach_loki(context, session)
 
     def _parse_progress_line(self, line: str) -> dict[str, Any] | None:

--- a/lb_app/services/run_service.py
+++ b/lb_app/services/run_service.py
@@ -24,6 +24,7 @@ from lb_app.services.run_context_builder import (
     resolve_target_tests,
 )
 from lb_app.services.run_execution import (
+    AttachedHandler,
     ControllerLogAttachmentService,
     RunExecutionCoordinator,
 )
@@ -31,7 +32,6 @@ from lb_app.services.execution_loop import RunExecutionLoop
 from lb_app.services.session_manager import SessionManager
 
 if TYPE_CHECKING:
-    from logging import Handler
     from lb_controller.api import RunExecutionSummary
     from lb_app.services.run_types import _EventPipeline, _RemoteSession
 
@@ -216,12 +216,12 @@ class RunService:
 
     def _attach_controller_jsonl(
         self, context: RunContext, session: _RemoteSession
-    ) -> Handler:
+    ) -> AttachedHandler:
         return self._execution_coordinator._attach_controller_jsonl(context, session)
 
     def _attach_controller_loki(
         self, context: RunContext, session: _RemoteSession
-    ) -> Handler | None:
+    ) -> AttachedHandler | None:
         return self._execution_coordinator._attach_controller_loki(context, session)
 
     def _prepare_remote_session(

--- a/lb_controller/services/run_catalog_service.py
+++ b/lb_controller/services/run_catalog_service.py
@@ -59,9 +59,9 @@ class RunCatalogService:
         hosts, workloads = self._extract_hosts_workloads(journal_data)
 
         if not hosts:
-            hosts = self._fallback_hosts(output_root)
-        if not workloads and hosts:
-            workloads = self._fallback_workloads(output_root, hosts)
+            hosts, workloads = self._fallback_layout_metadata(output_root)
+        elif not workloads:
+            workloads = self._fallback_remote_workloads(output_root, hosts)
 
         return RunInfo(
             run_id=run_id,
@@ -128,21 +128,59 @@ class RunCatalogService:
         }
         return hosts, workloads
 
-    @staticmethod
-    def _fallback_hosts(output_root: Path) -> Set[str]:
-        return {entry.name for entry in output_root.iterdir() if entry.is_dir()}
+    @classmethod
+    def _fallback_layout_metadata(cls, output_root: Path) -> tuple[Set[str], Set[str]]:
+        entries = cls._candidate_dirs(output_root)
+        if not entries:
+            return set(), set()
+
+        local_workloads = {
+            entry.name for entry in entries if cls._looks_like_workload_dir(entry)
+        }
+        if local_workloads and len(local_workloads) == len(entries):
+            return {"localhost"}, local_workloads
+
+        remote_hosts = {entry.name for entry in entries if cls._looks_like_host_dir(entry)}
+        if remote_hosts:
+            return remote_hosts, cls._fallback_remote_workloads(output_root, remote_hosts)
+
+        return set(), set()
+
+    @classmethod
+    def _fallback_remote_workloads(cls, output_root: Path, hosts: Set[str]) -> Set[str]:
+        workloads: set[str] = set()
+        for host in hosts:
+            host_root = output_root / host
+            if not host_root.exists():
+                continue
+            for entry in cls._candidate_dirs(host_root):
+                if cls._looks_like_workload_dir(entry):
+                    workloads.add(entry.name)
+        return workloads
 
     @staticmethod
-    def _fallback_workloads(output_root: Path, hosts: Set[str]) -> Set[str]:
-        first_host = next(iter(hosts))
-        host_root = output_root / first_host
-        if not host_root.exists():
-            return set()
-        return {
-            entry.name
-            for entry in host_root.iterdir()
-            if entry.is_dir() and not entry.name.startswith("_")
-        }
+    def _candidate_dirs(root: Path) -> list[Path]:
+        return [
+            entry
+            for entry in root.iterdir()
+            if entry.is_dir() and not entry.name.startswith("_") and entry.name != "logs"
+        ]
+
+    @classmethod
+    def _looks_like_host_dir(cls, root: Path) -> bool:
+        children = cls._candidate_dirs(root)
+        return any(cls._looks_like_workload_dir(child) for child in children)
+
+    @staticmethod
+    def _looks_like_workload_dir(root: Path) -> bool:
+        has_children = False
+        for entry in root.iterdir():
+            has_children = True
+            if entry.is_dir() and entry.name.startswith("rep"):
+                return True
+            if entry.is_file() and entry.name.endswith("_results.json"):
+                return True
+        return not has_children
 
     def _iter_run_ids(self) -> Iterable[str]:
         for item in self.output_dir.iterdir():

--- a/lb_runner/engine/executor.py
+++ b/lb_runner/engine/executor.py
@@ -198,7 +198,12 @@ class RepetitionExecutor:
                 collectors_enabled=collectors_enabled,
             )
             self._cleanup_generator(generator, test_name, repetition)
-            self._process_results(test_name, [result], plugin=plugin)
+            self._process_results(
+                test_name,
+                [result],
+                plugin=plugin,
+                export_results=False,
+            )
             success = bool(result.get("success", True))
             message = "" if success else str(result.get("error") or "")
             return RepetitionOutcome(
@@ -341,6 +346,7 @@ class RepetitionExecutor:
         results: list[dict[str, Any]],
         *,
         plugin: WorkloadPlugin | None = None,
+        export_results: bool = True,
     ) -> None:
         target_root = self.context.output_manager.workload_output_dir(test_name)
         self.context.output_manager.process_results(
@@ -348,6 +354,7 @@ class RepetitionExecutor:
             results=results,
             target_root=target_root,
             test_name=test_name,
+            export_results=export_results,
         )
 
     def _handle_failure(
@@ -384,7 +391,12 @@ class RepetitionExecutor:
         self._cleanup_generator(generator, test_name, repetition)
         try:
             self.context.output_manager.persist_rep_result(rep_dir, result)
-            self._process_results(test_name, [result], plugin=plugin)
+            self._process_results(
+                test_name,
+                [result],
+                plugin=plugin,
+                export_results=False,
+            )
         except Exception:
             logger.exception(
                 "Failed to persist failure result for %s rep %s",

--- a/lb_runner/engine/runner.py
+++ b/lb_runner/engine/runner.py
@@ -166,30 +166,32 @@ class LocalRunner:
             plugin: WorkloadPlugin = self.plugin_registry.get(workload_cfg.plugin)
 
             success_overall = True
-            for idx, rep in enumerate(reps):
-                success = self._run_single_repetition(
-                    test_type=test_type,
-                    workload_cfg=workload_cfg,
-                    plugin=plugin,
-                    repetition=rep,
-                    total_reps=total_reps,
-                )
-                success_overall = success_overall and success
-
-                if idx < len(reps) - 1 and self.config.cooldown_seconds > 0:
-                    logger.info(
-                        "Cooldown period: %s seconds", self.config.cooldown_seconds
+            try:
+                for idx, rep in enumerate(reps):
+                    success = self._run_single_repetition(
+                        test_type=test_type,
+                        workload_cfg=workload_cfg,
+                        plugin=plugin,
+                        repetition=rep,
+                        total_reps=total_reps,
                     )
-                    if not sleep_with_stop_checks(
-                        self.config.cooldown_seconds,
-                        self._stop_token,
-                        interval_seconds=0.1,
-                    ):
+                    success_overall = success_overall and success
+
+                    if idx < len(reps) - 1 and self.config.cooldown_seconds > 0:
+                        logger.info(
+                            "Cooldown period: %s seconds", self.config.cooldown_seconds
+                        )
+                        if not sleep_with_stop_checks(
+                            self.config.cooldown_seconds,
+                            self._stop_token,
+                            interval_seconds=0.1,
+                        ):
+                            break
+
+                    if should_stop(self._stop_token):
                         break
-
-                if should_stop(self._stop_token):
-                    break
-
+            finally:
+                self._finalize_workload_results(test_type, plugin)
             logger.info(f"Completed benchmark: {test_type}")
             return success_overall
 
@@ -320,6 +322,21 @@ class LocalRunner:
             message=message,
             error_type=error_type,
             error_context=error_context,
+        )
+
+    def _finalize_workload_results(
+        self,
+        test_name: str,
+        plugin: WorkloadPlugin | None,
+    ) -> None:
+        """Flush deferred workload results into the aggregated JSON/exports."""
+        target_root = self._output_manager.workload_output_dir(test_name)
+        self._output_manager.process_results(
+            plugin=plugin,
+            results=[],
+            target_root=target_root,
+            test_name=test_name,
+            export_results=True,
         )
 
     def run_all_benchmarks(self) -> None:

--- a/lb_runner/metric_collectors/_base_collector.py
+++ b/lb_runner/metric_collectors/_base_collector.py
@@ -40,6 +40,7 @@ class BaseCollector(ABC):
         self._start_time: Optional[datetime] = None
         self._stop_time: Optional[datetime] = None
         self._errors: list[MetricCollectionError] = []
+        self.max_error_records = 100
 
     @abstractmethod
     def _collect_metrics(self) -> Dict[str, Any]:
@@ -100,9 +101,9 @@ class BaseCollector(ABC):
     def _collection_loop(self) -> None:
         """Main collection loop that runs in a background thread."""
         while self._is_running:
+            start = time.time()
+            failed = False
             try:
-                start = time.time()
-
                 # Collect metrics
                 metrics = self._collect_metrics()
 
@@ -114,21 +115,35 @@ class BaseCollector(ABC):
                 with self._lock:
                     self._data.append(metrics)
 
-                # Sleep for the remaining interval time
-                elapsed = time.time() - start
-                sleep_time = max(0, self.interval_seconds - elapsed)
-                if sleep_time > 0:
-                    time.sleep(sleep_time)
-
             except Exception as e:
+                failed = True
                 error = MetricCollectionError(
                     f"{self.name} collector failed to collect metrics",
                     context={"collector": self.name},
                     cause=e,
                 )
-                self._errors.append(error)
+                self._record_error(error)
                 logger.error("Error in %s collector: %s", self.name, e, exc_info=True)
-                # Continue collecting even on error
+            self._sleep_remaining(start, failed=failed)
+
+    def _record_error(self, error: MetricCollectionError) -> None:
+        """Store only the most recent collector errors."""
+        self._errors.append(error)
+        overflow = len(self._errors) - self.max_error_records
+        if overflow > 0:
+            del self._errors[:overflow]
+
+    def _sleep_remaining(self, start_time: float, *, failed: bool) -> None:
+        """Sleep to preserve the configured interval after each iteration."""
+        if not self._is_running:
+            return
+        elapsed = time.time() - start_time
+        if failed:
+            sleep_time = self.interval_seconds
+        else:
+            sleep_time = max(0.0, self.interval_seconds - elapsed)
+        if sleep_time > 0:
+            time.sleep(sleep_time)
 
     def get_data(self) -> List[Dict[str, Any]]:
         """

--- a/lb_runner/services/result_persister.py
+++ b/lb_runner/services/result_persister.py
@@ -8,6 +8,7 @@ from typing import Any
 from lb_plugins.api import WorkloadPlugin
 from lb_runner.services.results import (
     export_plugin_results,
+    merge_result_entries,
     merge_results,
     persist_rep_result,
     persist_results,
@@ -19,9 +20,11 @@ class ResultPersister:
 
     def __init__(self, run_id: str | None = None) -> None:
         self._run_id = run_id or ""
+        self._merged_results: dict[Path, list[dict[str, Any]]] = {}
 
     def set_run_id(self, run_id: str | None) -> None:
         self._run_id = run_id or ""
+        self._merged_results.clear()
 
     def persist_rep_result(self, rep_dir: Path, result: dict[str, Any]) -> None:
         persist_rep_result(rep_dir, result)
@@ -32,14 +35,33 @@ class ResultPersister:
         results: list[dict[str, Any]],
         target_root: Path,
         test_name: str,
+        *,
+        export_results: bool = True,
     ) -> None:
         results_file = target_root / f"{test_name}_results.json"
-        merged_results = merge_results(results_file, results)
+        merged_results = self._merge_results(results_file, results)
+        if not merged_results and not results_file.exists():
+            self._merged_results.pop(results_file, None)
+            return
+
         persist_results(results_file, merged_results)
-        export_plugin_results(
-            plugin,
-            merged_results,
-            target_root,
-            test_name,
-            self._run_id,
-        )
+        if export_results:
+            export_plugin_results(
+                plugin,
+                merged_results,
+                target_root,
+                test_name,
+                self._run_id,
+            )
+            self._merged_results.pop(results_file, None)
+
+    def _merge_results(
+        self, results_file: Path, new_results: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        cached = self._merged_results.get(results_file)
+        if cached is None:
+            merged = merge_results(results_file, new_results)
+        else:
+            merged = merge_result_entries(cached, new_results)
+        self._merged_results[results_file] = merged
+        return merged

--- a/lb_runner/services/results.py
+++ b/lb_runner/services/results.py
@@ -151,14 +151,25 @@ def merge_results(
         except Exception:
             merged = []
 
+    return merge_result_entries(merged, new_results)
+
+
+def merge_result_entries(
+    existing_results: list[dict[str, Any]],
+    new_results: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Merge repetition-keyed result entries, preferring newer payloads."""
+
     def _rep_key(entry: dict[str, Any]) -> int | None:
         rep_val = entry.get("repetition")
         return rep_val if isinstance(rep_val, int) and rep_val > 0 else None
 
     merged_by_rep: dict[int, dict[str, Any]] = {
-        rep: entry for entry in merged if (rep := _rep_key(entry)) is not None
+        rep: entry for entry in existing_results if (rep := _rep_key(entry)) is not None
     }
-    unkeyed: list[dict[str, Any]] = [e for e in merged if _rep_key(e) is None]
+    unkeyed: list[dict[str, Any]] = [
+        entry for entry in existing_results if _rep_key(entry) is None
+    ]
     for entry in new_results:
         rep = _rep_key(entry)
         if rep is None:

--- a/lb_runner/services/runner_output_manager.py
+++ b/lb_runner/services/runner_output_manager.py
@@ -62,10 +62,12 @@ class RunnerOutputManager:
         results: list[dict[str, Any]],
         target_root: Path,
         test_name: str,
+        export_results: bool = True,
     ) -> None:
         self.persister.process_results(
             plugin=plugin,
             results=results,
             target_root=target_root,
             test_name=test_name,
+            export_results=export_results,
         )

--- a/lb_ui/tui/system/components/dashboard.py
+++ b/lb_ui/tui/system/components/dashboard.py
@@ -166,7 +166,9 @@ class RichDashboard(Dashboard):
     def _supports_key_toggle(self) -> bool:
         if os.name == "nt":
             return False
-        if termios is None or tty is None:
+        if getattr(termios, "tcgetattr", None) is None:
+            return False
+        if getattr(tty, "setcbreak", None) is None:
             return False
         try:
             return sys.stdin.isatty()
@@ -174,10 +176,15 @@ class RichDashboard(Dashboard):
             return False
 
     def _key_listener_loop(self) -> None:
-        fd = sys.stdin.fileno()
-        old_attrs = termios.tcgetattr(fd)
         try:
-            tty.setcbreak(fd)
+            import termios as termios_module
+            import tty as tty_module
+        except ImportError:
+            return
+        fd = sys.stdin.fileno()
+        old_attrs = termios_module.tcgetattr(fd)
+        try:
+            tty_module.setcbreak(fd)
             while not self._key_listener_stop.is_set():
                 ready, _, _ = select.select([fd], [], [], 0.1)
                 if not ready:
@@ -189,7 +196,7 @@ class RichDashboard(Dashboard):
             return
         finally:
             try:
-                termios.tcsetattr(fd, termios.TCSADRAIN, old_attrs)
+                termios_module.tcsetattr(fd, termios_module.TCSADRAIN, old_attrs)
             except Exception:
                 pass
 

--- a/tests/unit/lb_app/test_controller_log_handlers.py
+++ b/tests/unit/lb_app/test_controller_log_handlers.py
@@ -1,0 +1,42 @@
+"""Tests for controller log handler ownership and cleanup."""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+from lb_app.services.remote_run_coordinator import ControllerLogHandlers
+from lb_app.services.run_execution import AttachedHandler
+
+
+class _Service:
+    def __init__(self) -> None:
+        self.controller_logger = logging.getLogger("lb_controller")
+        self.root_logger = logging.getLogger()
+        self.jsonl_handler = AttachedHandler(
+            logger=self.controller_logger,
+            handler=logging.NullHandler(),
+        )
+        self.loki_handler = AttachedHandler(
+            logger=self.root_logger,
+            handler=logging.NullHandler(),
+        )
+
+    def _attach_controller_jsonl(self, *_args, **_kwargs):
+        self.controller_logger.addHandler(self.jsonl_handler.handler)
+        return self.jsonl_handler
+
+    def _attach_controller_loki(self, *_args, **_kwargs):
+        self.root_logger.addHandler(self.loki_handler.handler)
+        return self.loki_handler
+
+
+def test_controller_log_handlers_remove_from_owning_logger() -> None:
+    service = _Service()
+
+    with ControllerLogHandlers(service, SimpleNamespace(), SimpleNamespace()):
+        assert service.jsonl_handler.handler in service.controller_logger.handlers
+        assert service.loki_handler.handler in service.root_logger.handlers
+
+    assert service.jsonl_handler.handler not in service.controller_logger.handlers
+    assert service.loki_handler.handler not in service.root_logger.handlers

--- a/tests/unit/lb_app/test_remote_run_coordinator.py
+++ b/tests/unit/lb_app/test_remote_run_coordinator.py
@@ -47,6 +47,20 @@ class _DummyService:
         return self.summary
 
 
+class _FailingService(_DummyService):
+    def __init__(self, session, pipeline) -> None:
+        super().__init__(
+            session,
+            short_result=RunResult(context=_make_context(), summary=None),
+            pipeline=pipeline,
+            summary=None,
+        )
+
+    def _run_controller_loop(self, *_args, **_kwargs):
+        self.run_called = True
+        raise RuntimeError("boom")
+
+
 def _make_context() -> RunContext:
     cfg = BenchmarkConfig()
     cfg.remote_hosts = [RemoteHostConfig(name="host", address="127.0.0.1", user="root")]
@@ -119,6 +133,63 @@ def test_remote_run_short_circuits_when_no_pending(
     assert result is short_result
 
 
+def test_remote_run_short_circuit_cleans_up_session_resources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    class _StopToken:
+        def __init__(self) -> None:
+            self._on_stop = None
+
+        def should_stop(self) -> bool:
+            return False
+
+        def restore(self) -> None:
+            events.append("restore")
+
+    session = _make_session(_StopToken())
+    session.sink = SimpleNamespace(close=lambda: events.append("sink_close"))
+    session.log_file = SimpleNamespace(
+        write=lambda *_: None,
+        flush=lambda: None,
+        close=lambda: events.append("log_close"),
+    )
+    session.ui_stream_log_file = SimpleNamespace(
+        close=lambda: events.append("ui_close")
+    )
+    short_result = RunResult(context=_make_context(), summary=None)
+    service = _DummyService(session, short_result, _make_pipeline(), summary=None)
+    coordinator = RemoteRunCoordinator(service)
+
+    monkeypatch.setattr(
+        coordinator_mod, "pending_exists", lambda *args, **kwargs: False
+    )
+    monkeypatch.setattr(coordinator_mod, "apply_playbook_defaults", lambda *_: None)
+    monkeypatch.setattr(
+        coordinator_mod, "apply_plugin_assets", lambda *_args, **_kwargs: None
+    )
+
+    result = coordinator.run(
+        _make_context(),
+        run_id="run-1",
+        output_callback=lambda *_: None,
+        formatter=None,
+        ui_adapter=None,
+        stop_token=session.stop_token,
+        emit_timing=False,
+    )
+
+    assert service.short_circuit_called is True
+    assert service.pipeline_called is False
+    assert service.run_called is False
+    assert result is short_result
+    assert "sink_close" in events
+    assert "restore" in events
+    assert "log_close" in events
+    assert "ui_close" in events
+
+
 def test_remote_run_executes_when_pending(monkeypatch: pytest.MonkeyPatch) -> None:
     stop_token = StopToken(enable_signals=False)
     session = _make_session(stop_token)
@@ -157,3 +228,52 @@ def test_remote_run_executes_when_pending(monkeypatch: pytest.MonkeyPatch) -> No
     assert service.pipeline_called is True
     assert service.run_called is True
     assert result.summary is summary
+
+
+def test_remote_run_cleans_up_when_controller_loop_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stop_events: list[str] = []
+
+    class _StopToken:
+        def __init__(self) -> None:
+            self._on_stop = None
+
+        def should_stop(self) -> bool:
+            return False
+
+        def restore(self) -> None:
+            stop_events.append("restore")
+
+    session = _make_session(_StopToken())
+    session.sink = SimpleNamespace(close=lambda: stop_events.append("sink_close"))
+    tailer = SimpleNamespace(stop=lambda: stop_events.append("tailer_stop"))
+    service = _FailingService(session, _make_pipeline())
+    coordinator = RemoteRunCoordinator(service)
+
+    monkeypatch.setattr(coordinator_mod, "pending_exists", lambda *args, **kwargs: True)
+    monkeypatch.setattr(coordinator_mod, "apply_playbook_defaults", lambda *_: None)
+    monkeypatch.setattr(
+        coordinator_mod, "apply_plugin_assets", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        coordinator_mod, "maybe_start_event_tailer", lambda *_args, **_kwargs: tailer
+    )
+    monkeypatch.setattr(
+        coordinator_mod, "BenchmarkController", lambda *_args, **_kwargs: object()
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        coordinator.run(
+            _make_context(),
+            run_id="run-1",
+            output_callback=lambda *_: None,
+            formatter=None,
+            ui_adapter=None,
+            stop_token=session.stop_token,
+            emit_timing=False,
+        )
+
+    assert "tailer_stop" in stop_events
+    assert "sink_close" in stop_events
+    assert "restore" in stop_events

--- a/tests/unit/lb_controller/test_run_catalog_layouts.py
+++ b/tests/unit/lb_controller/test_run_catalog_layouts.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from lb_controller.api import RunCatalogService
+
+
+def test_get_run_understands_local_layout_without_journal(tmp_path: Path) -> None:
+    output_dir = tmp_path / "benchmark_results"
+    run_dir = output_dir / "run-1"
+    (run_dir / "stress_ng" / "rep1").mkdir(parents=True)
+
+    info = RunCatalogService(output_dir).get_run("run-1")
+
+    assert info is not None
+    assert info.hosts == ["localhost"]
+    assert info.workloads == ["stress_ng"]
+
+
+def test_get_run_understands_remote_layout_without_journal(tmp_path: Path) -> None:
+    output_dir = tmp_path / "benchmark_results"
+    run_dir = output_dir / "run-2"
+    (run_dir / "host-a" / "stress_ng" / "rep1").mkdir(parents=True)
+    (run_dir / "host-b" / "fio" / "rep1").mkdir(parents=True)
+
+    info = RunCatalogService(output_dir).get_run("run-2")
+
+    assert info is not None
+    assert info.hosts == ["host-a", "host-b"]
+    assert info.workloads == ["fio", "stress_ng"]

--- a/tests/unit/lb_runner/engine_tests/test_base_collector_failure_policy.py
+++ b/tests/unit/lb_runner/engine_tests/test_base_collector_failure_policy.py
@@ -1,0 +1,44 @@
+"""Tests for BaseCollector failure backoff and error history policy."""
+
+from __future__ import annotations
+
+import time
+
+from tests.unit.lb_runner.engine_tests.test_base_collector import DummyCollector
+
+
+def test_failing_collector_sleeps_between_failures(
+    monkeypatch,
+) -> None:
+    sleeps: list[float] = []
+    collector = DummyCollector(interval_seconds=0.5, raise_on_collect=True)
+    collector._is_running = True
+
+    def fake_sleep(value: float) -> None:
+        sleeps.append(value)
+        collector._is_running = False
+
+    monkeypatch.setattr(time, "sleep", fake_sleep)
+
+    collector._collection_loop()
+
+    assert sleeps
+    assert sleeps[0] >= 0.5
+
+
+def test_failing_collector_caps_error_history(monkeypatch) -> None:
+    sleeps: list[float] = []
+    collector = DummyCollector(interval_seconds=0.01, raise_on_collect=True)
+    collector.max_error_records = 3
+    collector._is_running = True
+
+    def fake_sleep(value: float) -> None:
+        sleeps.append(value)
+        if len(sleeps) >= 5:
+            collector._is_running = False
+
+    monkeypatch.setattr(time, "sleep", fake_sleep)
+
+    collector._collection_loop()
+
+    assert len(collector.get_errors()) == 3

--- a/tests/unit/lb_runner/engine_tests/test_executor.py
+++ b/tests/unit/lb_runner/engine_tests/test_executor.py
@@ -154,3 +154,20 @@ def test_run_attempt_handles_lb_error(executor, context, tmp_path):
     assert outcome.status == "failed"
     assert context.output_manager.persist_rep_result.called
     assert context.output_manager.process_results.called
+
+
+def test_run_attempt_defers_export_until_last_repetition(executor, context, tmp_path):
+    generator = MagicMock()
+    result = {"success": True, "repetition": 1}
+    context.output_manager.workload_output_dir.return_value = tmp_path / "workload"
+
+    with patch.object(executor, "execute", return_value=result):
+        outcome = executor.run_attempt(
+            test_name="test_workload",
+            generator=generator,
+            repetition=1,
+            total_repetitions=3,
+        )
+
+    assert outcome.success is True
+    assert context.output_manager.process_results.call_args.kwargs["export_results"] is False

--- a/tests/unit/lb_runner/services_tests/test_result_persister_incremental.py
+++ b/tests/unit/lb_runner/services_tests/test_result_persister_incremental.py
@@ -1,0 +1,108 @@
+"""Tests for incremental result persistence/export behavior."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import lb_runner.services.result_persister as result_persister_mod
+from lb_runner.services.result_persister import ResultPersister
+
+
+def test_process_results_writes_aggregate_json_and_exports_once(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    plugin = MagicMock()
+    plugin.export_results_to_csv.return_value = []
+    persister = ResultPersister(run_id="run-1")
+    results_path = tmp_path / "stress_ng_results.json"
+    merge_spy = MagicMock(wraps=result_persister_mod.merge_results)
+    monkeypatch.setattr(result_persister_mod, "merge_results", merge_spy)
+
+    persister.process_results(
+        plugin,
+        [{"repetition": 1, "value": "a"}],
+        tmp_path,
+        "stress_ng",
+        export_results=False,
+    )
+
+    assert results_path.exists()
+    assert json.loads(results_path.read_text()) == [{"repetition": 1, "value": "a"}]
+    assert plugin.export_results_to_csv.call_count == 0
+    assert merge_spy.call_count == 1
+
+    persister.process_results(
+        plugin,
+        [{"repetition": 2, "value": "b"}],
+        tmp_path,
+        "stress_ng",
+        export_results=False,
+    )
+
+    assert json.loads(results_path.read_text()) == [
+        {"repetition": 1, "value": "a"},
+        {"repetition": 2, "value": "b"},
+    ]
+    assert plugin.export_results_to_csv.call_count == 0
+    assert merge_spy.call_count == 1
+
+    persister.process_results(
+        plugin,
+        [],
+        tmp_path,
+        "stress_ng",
+        export_results=True,
+    )
+
+    assert plugin.export_results_to_csv.call_count == 1
+    exported = plugin.export_results_to_csv.call_args.kwargs["results"]
+    assert exported == [
+        {"repetition": 1, "value": "a"},
+        {"repetition": 2, "value": "b"},
+    ]
+
+    saved = json.loads(results_path.read_text())
+    assert saved == [
+        {"repetition": 1, "value": "a"},
+        {"repetition": 2, "value": "b"},
+    ]
+    assert merge_spy.call_count == 1
+
+
+def test_process_results_cache_is_instance_local(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    plugin = MagicMock()
+    plugin.export_results_to_csv.return_value = []
+    merge_spy = MagicMock(wraps=result_persister_mod.merge_results)
+    monkeypatch.setattr(result_persister_mod, "merge_results", merge_spy)
+
+    first = ResultPersister(run_id="run-1")
+    first.process_results(
+        plugin,
+        [{"repetition": 1, "value": "a"}],
+        tmp_path,
+        "stress_ng",
+        export_results=False,
+    )
+
+    second = ResultPersister(run_id="run-2")
+    second.process_results(
+        plugin,
+        [{"repetition": 2, "value": "b"}],
+        tmp_path,
+        "stress_ng",
+        export_results=True,
+    )
+
+    results_path = tmp_path / "stress_ng_results.json"
+    assert json.loads(results_path.read_text()) == [
+        {"repetition": 1, "value": "a"},
+        {"repetition": 2, "value": "b"},
+    ]
+    assert merge_spy.call_count == 2
+    assert plugin.export_results_to_csv.call_count == 1

--- a/tests/unit/lb_runner/test_local_runner_unit.py
+++ b/tests/unit/lb_runner/test_local_runner_unit.py
@@ -72,6 +72,44 @@ def test_local_runner_merges_results_across_repetition_override_calls(
     assert [entry.get("repetition") for entry in data] == [1, 2]
 
 
+def test_local_runner_writes_partial_results_after_single_override_call(
+    tmp_path: Path,
+) -> None:
+    cfg = BenchmarkConfig(
+        output_dir=tmp_path / "out",
+        report_dir=tmp_path / "rep",
+        data_export_dir=tmp_path / "exp",
+        workloads={"dummy": WorkloadConfig(plugin="stress_ng")},
+        warmup_seconds=0,
+        cooldown_seconds=0,
+        collect_system_info=False,
+    )
+
+    plugin = MagicMock()
+    plugin.name = "stress_ng"
+    plugin.export_results_to_csv.return_value = []
+
+    registry = MagicMock()
+    registry.get.return_value = plugin
+    registry.create_collectors.return_value = []
+
+    generator = MagicMock()
+    generator.get_result.return_value = {"returncode": 0}
+    generator._is_running = False
+    registry.create_generator.return_value = generator
+
+    run_id = "run-partial-merge-test"
+    runner = LocalRunner(cfg, registry=registry)
+
+    assert runner.run_benchmark(
+        "dummy", repetition_override=1, total_repetitions=2, run_id=run_id
+    )
+
+    results_path = cfg.output_dir / run_id / "dummy" / "dummy_results.json"
+    data = json.loads(results_path.read_text(encoding="utf-8"))
+    assert [entry.get("repetition") for entry in data] == [1]
+
+
 def test_local_runner_attaches_and_detaches_handlers(tmp_path: Path) -> None:
     """LocalRunner should attach log handlers during run preparation."""
     cfg = BenchmarkConfig(


### PR DESCRIPTION
## Summary
This PR fixes the structural issues found in the run lifecycle and result persistence paths across `lb_app`, `lb_controller`, and `lb_runner`.

It makes controller log attachment ownership explicit so handlers are removed from the correct logger, guarantees remote session cleanup even when the controller loop raises, corrects fallback run catalog discovery for layouts without a journal, and adds a bounded failure policy for metric collectors to avoid tight retry loops.

It also reworks result persistence so merged workload results are cached and plugin export is deferred to workload finalization, which removes repeated full-file rereads and repeated export work on every repetition while preserving incremental aggregate output.

A small follow-up static-analysis cleanup aligns `AttachedHandler` typing in the app layer and removes a mypy-unreachable artifact in the dashboard key-listener path.

## Validation
- `uv run pytest tests/unit/lb_app tests/unit/lb_controller tests/unit/lb_runner -q`
- `uv run pytest tests/unit/lb_ui/test_cli_resume_catalog.py tests/unit/lb_gui/test_services.py -q`
- `uv run pytest tests/integration/test_cli_resume.py tests/integration/test_resume_pending_repetitions.py tests/integration/test_resume_provisioning.py -q`
- `bash scripts/mypy_core.sh`
- `bash scripts/mypy_plugins.sh`
- `uv run lint-imports`
- `uv run pytest tests/unit/lint/test_import_boundaries.py -q`